### PR TITLE
Corrections to Day3-05

### DIFF
--- a/Day-3/05-intro-to-statistics-for-bioinformatics-II.md
+++ b/Day-3/05-intro-to-statistics-for-bioinformatics-II.md
@@ -74,7 +74,7 @@ As we discussed above, at a 5% significance level, there is a 5% chance of rejec
 We can demonstrate the multiple testing problem by simulating some very simple data that come from exactly the same distribution, and therefore should have no significant differences between them, so we should never reject the null in theory.
 
 ```r
-# generate an expty vector to store P-values in
+# generate an empty vector to store P-values in
 p.value <- c()
 
 # generate 2 random variables (r.v.s) 1000 times and run a t.test on each pair of r.v.s
@@ -150,7 +150,7 @@ text(600, 1.5, "Original threshold")
 We can also calculate a new set of P-values that have been adjusted by the Bonferonni method (P-values are multiplied by the number of comparisons), which can be evaluated at the 0.05 significance value.
 ```r
 # bonferroni correction
-p.adj.bonf <- p.adjust(p.value, method = "FWER")
+p.adj.bonf <- p.adjust(p.value, method = "bonferroni")
 p.adj.bonf
 
 # check if any are signifciant
@@ -179,6 +179,7 @@ You can calculate q-values using the Bioconductor package `qvalue`.
 #BiocManager::install("qvalue")
 # library(qvalue)
 qvalue(p.value)$qvalues
+p.adj.fdr <- qvalue(p.value)$qvalues
 
 # check how many are sig.
 table(p.adj.fdr < 0.05)
@@ -209,7 +210,7 @@ Understanding the basics of linear modeling is central to being able to perform 
 
 Given their importance and pervasive use in bioinformatics and genomics, we will introduce the fundamental concepts of linear models, and how you can fit these models in R.
 
-> **Note:** Linear modeling is the topic of entire independent courses and again requires knowledge of appropriate mathematics and proprability to understand completely. Thus, this should be considered an introduction rather than a standalone resurce.
+> **Note:** Linear modeling is the topic of entire independent courses and again requires knowledge of appropriate mathematics and propbability to understand completely. Thus, this should be considered an introduction rather than a standalone resource.
 
 In a standard linear model, we assume that some *response* variable (*Y*) can be represented as a linear combination of a set of *predictors* (*X*, independent variables). In building a linear model, we estimate a set of *coefficients* that explain how the *predictors* are related to the *response*. We can use these *coefficients* for statistical inference to better understand which predictors are associated with our response, or for applying the model to new data where we wish to predict the response variable using only a set of predictors.
 
@@ -337,6 +338,7 @@ plot(dat2$gene_exp ~ dat2$hba1c,
 # fit a linear model with gene expression as the response
 lm1 <- lm(dat2$gene_exp ~ dat2$hba1c)
 summary(lm1)
+pre <- predict(lm1)
 
 # add the model on the scatterplot
 abline(lm1, lty=2)
@@ -360,7 +362,7 @@ In genomics, we commonly have categorial predictor variables, in contrast to the
 - Vehicle vs treatment
 - Control vs diseased
 
-Importantly, linear models are capable of incorportaing categorical variables as predictors. Lets consider another example, where we have gene expression levels for gene X measured in 20 healthy tissues, and 20 diseased tissues, and we wish to use a linear model to explore the relationship between gene expression and disease status.
+Importantly, linear models are capable of incorporating categorical variables as predictors. Lets consider another example, where we have gene expression levels for gene X measured in 20 healthy tissues, and 20 diseased tissues, and we wish to use a linear model to explore the relationship between gene expression and disease status.
 
 ```r
 # read in the example data


### PR DESCRIPTION
Description of proposed changes:
Line 77, 213, 365 -- small spelling corrections
Line 154 -- The method 'FWER' doesn't exist.  I tried in both R 3.6 and R 4.0.  Available methods are: "holm", "hochberg", "hommel", "bonferroni", "BH", "BY", "fdr", "none" 
Line 184 -- object 'p.adj.fdr' not found.  I guess a line like 'p.adj.fdr <- qvalue(p.value)$qvalues' is missing.
Line 345 -- We need to run 'pre <- predict(lm1)' again here to recaluate the 'pre' variable from the new model, so the segments on the graph point to the right place.